### PR TITLE
Update to RC5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ReactiveFB provides an API that bridges the reactive world of RxJava 2.0 with th
 The aim of the library is to :
 
 - make the use of the facebook api easy and less boilerplate.
-- expose the facebook api methods to the possibilities of the reactive world like transformations, filtering, composition.. 
+- expose the facebook api methods to the possibilities of the reactive world like transformations, filtering, composition.
 
 ### Download :
 
@@ -17,7 +17,7 @@ compile 'com.beltaief.reactivefacebook:reactivefb:0.1.0-alpha.1'
 
 This lib depends on :
 - facebook-android-sdk:4.15.0
-- rxjava:2.0.0-RC3
+- rxjava:2.0.0-RC5
 - rxandroid:2.0.0-RC1
 
 
@@ -181,11 +181,11 @@ ReactiveRequest
             throwable -> Log.d(TAG, "onError " + throwable.getMessage()),
             () -> Log.d(TAG, "onComplete")
     );
-  
+
 private void addPhoto(Photo photo) {
   // add item
   mAdapter.addItem(photo);
-  
+
   // notify inserted
   ...
 }

--- a/reactivefb/build.gradle
+++ b/reactivefb/build.gradle
@@ -21,7 +21,7 @@ dependencies {
     })
     compile 'com.facebook.android:facebook-android-sdk:4.15.0'
 
-    compile 'io.reactivex.rxjava2:rxjava:2.0.0-RC3'
+    compile 'io.reactivex.rxjava2:rxjava:2.0.0-RC5'
     compile 'io.reactivex.rxjava2:rxandroid:2.0.0-RC1'
     testCompile 'junit:junit:4.12'
 }

--- a/reactivefb/src/main/java/com/beltaief/reactivefb/actions/ReactiveLogin.java
+++ b/reactivefb/src/main/java/com/beltaief/reactivefb/actions/ReactiveLogin.java
@@ -14,14 +14,13 @@ import java.util.List;
 
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
-import io.reactivex.internal.operators.maybe.MaybeFromObservable;
 
 import static com.beltaief.reactivefb.util.Checker.checkNotNull;
 
 /**
  * A static factory to create an Observable of login events.
  */
-public class ReactiveLogin {
+public final class ReactiveLogin {
 
     /**
      * Login with com.facebook.login.LoginManager
@@ -35,12 +34,12 @@ public class ReactiveLogin {
      * @return a Maybe of LoginResult
      */
     @NonNull
-    public static Maybe<LoginResult> login(Activity activity) {
-        checkNotNull(activity, "view == null");
+    public static Maybe<LoginResult> login(@NonNull final Activity activity) {
+        checkNotNull(activity, "activity == null");
         // save a weak reference to the activity
         ReactiveFB.getSessionManager().setActivity(activity);
         // login
-        return MaybeFromObservable.create(new LoginOnSubscribe());
+        return Maybe.create(new LoginOnSubscribe());
     }
 
     /**
@@ -56,7 +55,7 @@ public class ReactiveLogin {
     @NonNull
     public static Observable<LoginResult> loginWithButton(@NonNull final LoginButton loginButton) {
 
-        checkNotNull(loginButton, "view == null");
+        checkNotNull(loginButton, "loginButton == null");
         ReactiveFB.checkInit();
         // login
         return Observable.create(new LoginWithButtonOnSubscribe(loginButton));
@@ -72,9 +71,10 @@ public class ReactiveLogin {
      */
     @NonNull
     public static Observable<LoginResult> loginWithButton(@NonNull final LoginButton loginButton,
-                                                          @NonNull Fragment fragment) {
+                                                          @NonNull final Fragment fragment) {
 
-        checkNotNull(loginButton, "fragment == null");
+        checkNotNull(fragment, "fragment == null");
+        checkNotNull(loginButton, "loginButton == null");
         ReactiveFB.checkInit();
         // login
         return Observable.create(new LoginWithButtonOnSubscribe(loginButton));
@@ -90,9 +90,10 @@ public class ReactiveLogin {
      */
     @NonNull
     public static Observable<LoginResult> loginWithButton(@NonNull final LoginButton loginButton,
-                                                          @NonNull android.app.Fragment fragment) {
+                                                          @NonNull final android.app.Fragment fragment) {
 
-        checkNotNull(loginButton, "fragment == null");
+        checkNotNull(fragment, "fragment == null");
+        checkNotNull(loginButton, "loginButton == null");
         ReactiveFB.checkInit();
         // login
         return Observable.create(new LoginWithButtonOnSubscribe(loginButton));
@@ -122,14 +123,18 @@ public class ReactiveLogin {
      * @param activity    current activity instance
      * @return a Maybe of LoginResult.
      */
-    public static Maybe<LoginResult> requestAdditionalPermission(List<PermissionHelper> permissions,
-                                                                 Activity activity) {
+    public static Maybe<LoginResult> requestAdditionalPermission(@NonNull final List<PermissionHelper> permissions,
+                                                                 @NonNull final Activity activity) {
 
         checkNotNull(permissions, "permissions == null");
-        checkNotNull(activity, "permissions == null");
+        checkNotNull(activity, "activity == null");
 
         ReactiveFB.getSessionManager().setActivity(activity);
 
-        return MaybeFromObservable.create(new AdditionalPermissionOnSubscribe(permissions));
+        return Maybe.create(new AdditionalPermissionOnSubscribe(permissions));
+    }
+
+    private ReactiveLogin() {
+        throw new AssertionError("No instances.");
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':reactivefb', ':reactivefbmodels'
+include ':app', ':reactivefb'


### PR DESCRIPTION
- updates to rxjava rc5
- removes the unused gradle module `reactivefbmodels`
- makes ReactiveLogin final and non instantiable
- fix error messages in ReactiveLogin and add a few that were missing
